### PR TITLE
Enforce consistent use of identifiers through a text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ of putting new-lines inside brackets.
 - The Go module is renamed from `lib` to `mg` to provide a short and distinctive
   import name.
 
+- Simple labels (e.g. `else:`) are now blocked from also being used as an
+  ordinary identifier, improving the robustness of the parse in a variety of
+  situations.
+
 
 ### Added
 

--- a/go/monogram/mg/parser.go
+++ b/go/monogram/mg/parser.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+type HowIdentsAreUsed uint8
+
+const (
+	NotUsedYet HowIdentsAreUsed = iota
+	UsedAsIdentifier
+	UsedAsLabel
+)
+
 // Parser holds the list of tokens and our current reading position.
 type Parser struct {
 	tokens       []*Token
@@ -12,6 +20,18 @@ type Parser struct {
 	UnglueOption *Token
 	IncludeSpans bool
 	Decimal      bool
+	Idents       map[string]HowIdentsAreUsed
+}
+
+func NewParser(tokens []*Token, defaultLabel string, includeSpans bool, decimal bool) *Parser {
+	return &Parser{
+		tokens:       tokens,
+		pos:          0,
+		UnglueOption: &Token{Type: Identifier, SubType: IdentifierVariable, Text: defaultLabel},
+		IncludeSpans: includeSpans,
+		Decimal:      decimal,
+		Idents:       make(map[string]HowIdentsAreUsed),
+	}
 }
 
 type Context struct {
@@ -94,7 +114,7 @@ func (p *Parser) readOptExprPrec(formStart *Token, outer_prec int, context Conte
 	if token.Type == Identifier && token.SubType == IdentifierFormEnd {
 		return nil, nil
 	}
-	if token.Type == Identifier && token.SubType == IdentifierVariable && token.IsBreaker(formStart) {
+	if token.Type == Identifier && token.SubType == IdentifierVariable && token.IsLabelToken(formStart) {
 		return nil, nil
 	}
 	if token.Type == Sign && token.SubType == SignLabel {
@@ -362,9 +382,13 @@ func (p *Parser) readFormExpr(formStart *Token, context Context) (*Node, error) 
 				first_expr_in_part = false
 				prev_expr_terminated = p.tryReadSemi()
 			}
-		} else if token.IsSimpleBreaker() {
+		} else if token.IsSimpleLabelToken() {
 			lc34 := p.endLineCol()
-			p.next() // skip the breaker
+			t := p.next() // skip the label
+			e := p.SetAsLabel(t.Text)
+			if e != nil {
+				return nil, e
+			}
 			p.next() // remove the ':'
 			new_currentKeyword := token
 
@@ -384,9 +408,9 @@ func (p *Parser) readFormExpr(formStart *Token, context Context) (*Node, error) 
 			currentPart = []*Node{}
 			first_expr_in_part = false
 			prev_expr_terminated = true
-		} else if token.IsCompoundBreaker(formStart) {
+		} else if token.IsCompoundLabelToken(formStart) {
 			lc34 := p.endLineCol()
-			t1 := p.next() // skip the breaker
+			t1 := p.next() // skip the label
 			t2 := p.next() // remove the '-
 			t3 := p.next() // remove the form-start
 
@@ -497,6 +521,22 @@ func (p *Parser) numberOptions(text string) (map[string]string, error) {
 	return options, nil
 }
 
+func (p *Parser) SetAsLabel(text string) error {
+	if p.Idents[text] == UsedAsIdentifier {
+		return fmt.Errorf("identifier used as label: %s", text)
+	}
+	p.Idents[text] = UsedAsLabel
+	return nil
+}
+
+func (p *Parser) SetAsIdentifier(text string) error {
+	if p.Idents[text] == UsedAsLabel {
+		return fmt.Errorf("labels used as identifier: %s", text)
+	}
+	p.Idents[text] = UsedAsIdentifier
+	return nil
+}
+
 func (p *Parser) doReadPrimaryExpr(context Context) (*Node, error) {
 	if !p.hasNext() {
 		return nil, fmt.Errorf("unexpected end of tokens")
@@ -541,16 +581,21 @@ func (p *Parser) doReadPrimaryExpr(context Context) (*Node, error) {
 					break
 				}
 
-				if p.peek().IsSimpleBreaker() {
+				if p.peek().IsSimpleLabelToken() {
 					t := p.next()
+					e := p.SetAsLabel(t.Text)
+					if e != nil {
+						return nil, e
+					}
 					p.next()
 					formBuilder.BeginNextPart(t.Text, p.endLineCol(), p.startLineCol())
 					startAgain = true
-				} else if p.peek().IsCompoundBreaker(token) {
-					t1 := p.next() // skip the breaker
+				} else if p.peek().IsCompoundLabelToken(token) {
+					t1 := p.next() // skip the label
 					t2 := p.next() // remove the '-
 					t3 := p.next() // remove the form-start
-					formBuilder.BeginNextPart(t1.Text+t2.Text+t3.Text, p.endLineCol(), p.startLineCol())
+					text := t1.Text + t2.Text + t3.Text
+					formBuilder.BeginNextPart(text, p.endLineCol(), p.startLineCol())
 					startAgain = true
 				} else if startAgain {
 					n, e := p.readOptExprPrec(token, maxPrecedence, cxt)
@@ -580,6 +625,11 @@ func (p *Parser) doReadPrimaryExpr(context Context) (*Node, error) {
 		} else {
 			switch token.SubType {
 			case IdentifierVariable:
+				if !token.EscapeSeen {
+					if e := p.SetAsIdentifier(token.Text); e != nil {
+						return nil, e
+					}
+				}
 				return &Node{
 					Name:    NameIdentifier,
 					Options: map[string]string{OptionName: token.Text},
@@ -716,13 +766,8 @@ func (p *Parser) convertLiteralExpressionStringSubToken(subToken *Token) (*Node,
 	return expressionNode, nil
 }
 
-func parseTokensToNodes(tokens []*Token, limit bool, breaker string, include_spans bool, decodeNumbers bool) ([]*Node, error) {
-	parser := &Parser{
-		tokens:       tokens,
-		UnglueOption: &Token{Type: Identifier, SubType: IdentifierVariable, Text: breaker},
-		IncludeSpans: include_spans,
-		Decimal:      decodeNumbers,
-	}
+func parseTokensToNodes(tokens []*Token, limit bool, defaultLabel string, includeSpans bool, decimal bool) ([]*Node, error) {
+	parser := NewParser(tokens, defaultLabel, includeSpans, decimal)
 	nodes := []*Node{}
 	for parser.hasNext() {
 		node, err := parser.readExpr(Context{})
@@ -738,7 +783,7 @@ func parseTokensToNodes(tokens []*Token, limit bool, breaker string, include_spa
 	return nodes, nil
 }
 
-func parseToASTArray(input string, limit bool, breaker string, include_spans bool, decodeNumbers bool, colOffset int) ([]*Node, Span, error) {
+func parseToASTArray(input string, limit bool, defaultLabel string, include_spans bool, decodeNumbers bool, colOffset int) ([]*Node, Span, error) {
 	// Step 1: Tokenize the input
 	tokens, span, terr := tokenizeInput(input, colOffset)
 	if terr != nil {
@@ -746,7 +791,7 @@ func parseToASTArray(input string, limit bool, breaker string, include_spans boo
 	}
 
 	// Step 2: Parse the tokens into nodes
-	nodes, err := parseTokensToNodes(tokens, limit, breaker, include_spans, decodeNumbers)
+	nodes, err := parseTokensToNodes(tokens, limit, defaultLabel, include_spans, decodeNumbers)
 	if err != nil {
 		return nil, Span{}, err
 	}

--- a/go/monogram/mg/parser_test.go
+++ b/go/monogram/mg/parser_test.go
@@ -18,12 +18,7 @@ func getParser(input string) (*Parser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getTokens error: %w", err)
 	}
-	parser := &Parser{
-		tokens:       tokens,
-		UnglueOption: &Token{Type: Identifier, SubType: IdentifierVariable, Text: "_"},
-		IncludeSpans: false,
-	}
-	return parser, nil
+	return NewParser(tokens, "_", false, false), nil
 }
 
 func TestParsePrefix0(t *testing.T) {

--- a/go/monogram/mg/token.go
+++ b/go/monogram/mg/token.go
@@ -30,8 +30,8 @@ const (
 	IdentifierVariable uint8 = iota
 	IdentifierFormStart
 	IdentifierFormEnd
-	IdentifierBreaker
-	IdentifierCompoundBreaker
+	IdentifierSimpleLabel
+	IdentifierCompoundLabel
 )
 
 // Subtypes for Punctuation
@@ -92,11 +92,11 @@ func (t *Token) QuoteWord() string {
 	}
 }
 
-func (t *Token) IsBreaker(formStart *Token) bool {
-	return t.IsSimpleBreaker() || t.IsCompoundBreaker(formStart)
+func (t *Token) IsLabelToken(formStart *Token) bool {
+	return t.IsSimpleLabelToken() || t.IsCompoundLabelToken(formStart)
 }
 
-func (t *Token) IsSimpleBreaker() bool {
+func (t *Token) IsSimpleLabelToken() bool {
 	if t.Type != Identifier || t.SubType != IdentifierVariable {
 		return false
 	}
@@ -112,7 +112,7 @@ func (t *Token) IsSimpleBreaker() bool {
 	return true
 }
 
-func (t *Token) IsCompoundBreaker(formStart *Token) bool {
+func (t *Token) IsCompoundLabelToken(formStart *Token) bool {
 	if t.Type != Identifier || t.SubType != IdentifierVariable {
 		return false
 	}
@@ -255,7 +255,7 @@ func (t *Token) VSCodeTokenType() string {
 		case IdentifierFormEnd:
 			// End markers can be styled as keywords
 			return "keyword"
-		case IdentifierBreaker, IdentifierCompoundBreaker:
+		case IdentifierSimpleLabel, IdentifierCompoundLabel:
 			return "operator"
 		default:
 			return "identifier"

--- a/go/monogram/mg/vscodeClassifyTokens.go
+++ b/go/monogram/mg/vscodeClassifyTokens.go
@@ -39,6 +39,11 @@ func VSCodeClassifyTokens(input io.Reader, output io.Writer) {
 		return
 	}
 
+	// Parse the tokens into nodes, which will side effect the tokens in the array
+	// allowing us to detect labels accurately. We can ignore any errors as we
+	// are only after the side-effect.
+	parseTokensToNodes(tokens, false, "_", false, false)
+
 	var classifications []TokenClassification = []TokenClassification{}
 
 	for _, token := range tokens {


### PR DESCRIPTION
- Prevents an identifier (e.g. `do`) being used as a variable in one place (e.g. `do += 1`) and a label a few lines on (e.g. `while  p do: p = f(p) endwhile`.
- Standardises the jargon on `label` rather than `breaker`.