### PR TITLE
Add Regular Expression literals

### DIFF
--- a/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
+++ b/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
@@ -51,6 +51,6 @@ is the basis on which we make that decision?
 
 ## Outcome and Consequences
 
-Option 2 would be a receipe for failure. Option 1 is no fun. Option 3 wins on 
+Option 2 would be a recipe for failure. Option 1 is no fun. Option 3 wins on 
 balance as the disadvantage is relatively minor.
 

--- a/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
+++ b/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
@@ -1,0 +1,56 @@
+# 0019 - Unicode characters beyond ASCII, 2025-05-20
+
+## Issue
+
+Should we expand the characters used in Monogram beyond Latin-1? And if so, what
+is the basis on which we make that decision?
+
+## Factors
+
+- Low adoption rates of programming languages that have gone beyond ASCII, let
+  alone Latin-1 e.g. APL, J, K, Uiua.
+- Difficulty in typing arbitrary Unicode characters.
+- Expansion in available syntax for improved readability.
+- Broad adoption of UTF-8 in text editors.
+- The existing inclusion of symbols for non-finite values, paired with
+  ASCII equivalents (`∞`, `0n1` etc).
+
+## Options
+
+- Option 1: Restrict the input to 7-bit ASCII
+- Option 2: Allow UTF-8
+- Option 3: Allow UTF-8 when paired with ASCII equivalents
+
+## Pros and Cons of Options
+
+### Option 1: Restrict the input to 7-bit ASCII
+- Pros
+  - Follows established and successful conventions
+  - Simplicity and clarity of policy
+- Cons
+  - Limits syntax expansion
+  - Misses the chance to use fun and helpful symbols
+
+### Option 2: Allow UTF-8
+- Pros
+  - Makes available fun and helpful symbols
+- Cons
+  - At the expense of a lack of familiarity
+  - Awkward to type for a high percentage of programmers
+
+### Option 3: Allow UTF-8 when paired with ASCII equivalents
+- Pros
+  - Makes available fun and helpful symbols
+- Cons
+  - Two versions of every symbol is a nuisance to remember
+    - So they must be memorable
+- Interesting
+  - Having an ASCII version means that a VSCode plug-in could perform
+    automatic substitution.
+
+
+## Outcome and Consequences
+
+Option 2 would be a receipe for failure. Option 1 is no fun. Option 3 wins on 
+balance as the disadvantage is relatively minor.
+

--- a/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
+++ b/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
@@ -1,0 +1,190 @@
+# 0020 - Extensible Literals, 2025-05-20
+
+## Issue
+
+To support extensible literals of arbitrary type, such as dates or IP addresses,
+it would be helpful to have another pair of brackets - but ones that were not
+already in wide use. This would allow a syntax such as: `TYPE(VALUE-TEXT)`. 
+This really means borrowing some alternative Unicode brackets that lie
+outside of the ASCII range. However, ASCII alternatives must be paired with
+these (and always available).
+
+
+Possible candidates would be:
+
+| Title                 | Open        | Close       | Example            | ASCII                |
+| --------------------- | ----------- | ----------- | ------------------ | -------------------- |
+| Angle Brackets        | 〈 (U+2329) | 〉 (U+232A) | date〈2025-05-20〉 | date<_2025-05-20_> |
+| Double Angle Brackets | « (U+00AB)  | » (U+00BB)  | date«2025-05-20»   | date<<2025-05-20>>   |
+| White Square Brackets | ⟦ (U+27E6)  | ⟧ (U+27E7)  | date⟦2025-05-20⟧   | date[\|2025-05-20\|] |
+| White Parentheses | ⦅ (U+2985)  | ⦆ (U+2986)  | date⦅2025-05-20⦆   | date(\|2025-05-20\|) |
+
+The specific proposal is to write literals in the following two styles:
+
+- `date⟦ 2025-05-20 ⟧`, the type of literal being explicitly stated.
+- `⟦ 192.168.0.1 ⟧`, the type not being stated and decision as to what the 
+  literal denotes is deferred.
+
+The first of these would be rendered in XML as:
+
+```xml
+<literal type="date" value="2025-05-20" />
+```
+
+and the second as follows:
+
+```xml
+<literal type="_" value="192.168.0.1" />
+```
+
+In this second example the default type would be `_` by default but could be
+overidden by the `--default-type=TYPENAME` option or the more elaborate option:
+
+```
+--match-type=TYPENAME,REGEX
+```
+
+If the `value` matches the REGEX of a given rule then the TYPENAME is inferred.
+Matches would be performed in the order of the option and the first match wins.
+
+
+## Factors
+
+- Impact on the parser
+- ASCII pairing
+- Visibility
+- Mnemonic role
+
+## Options
+
+- Option 1: Angle Brackets
+- Option 2: Double Angle Brackets
+- Option 3: White Square Brackets
+- Option 4: White Parentheses
+- Option 5: Don't have extensible literals, the vast majority of mainstream
+  programming languages get by with just procedure calls.
+
+## Pros and Cons of Options
+
+### Option 1: Angle Brackets
+
+- Cons
+    - Visually indistinct from `<` and `>`
+    - Conflicts with the planned XML tag syntax
+    - No memorable ASCII pairing
+    - No mnemonic relevance
+
+
+
+### Option 2: Double Angle Brackets
+- Pros
+    - Visually distinctive
+    - Mnemonic - these are speech marks in several European languages
+    - Has a strong ASCII pairing
+- Cons
+    - `<<` already has well-defined prefix and infix roles
+        - Showstopper.
+
+### Option 3: White Square Brackets
+
+- Pros
+    - Visually distinctive
+    - Good ASCII pairing
+- Cons
+    - Possible to implement in the parser without backtracking. But not efficient.
+- Interesting
+    - Weakly mnemonic, used to denote feature in linguistics and closed intervals
+      in maths e.g. `⟦0, 1⟧`. Both of these are suitable uses for extended
+      literals.
+
+
+
+### Option 4: White Parentheses
+- Pros
+    - Good ASCII pairing
+- Cons
+    - Existing fonts make it too confusable with standard parentheses.
+    - No efficient algorithm possible. Although backtracking can be avoided.
+    - No mnemonic aspect.
+
+### Option 5: Don't have extensible literals
+
+- Pros
+    - Simple to learn
+- Cons
+    - We force programmers to represent dates, IP addresses, colours as 
+      strings and to use function calls to convert them. 
+      - But Monogram has no built-in function calls, which pushes the 
+        effort back to the developer.
+
+
+## Outcome and Consequences
+
+Option 5 is viable but timid and fails to embrace the purely syntactic
+nature of Monogram. Option 2 would be the clear winner if `<<` and `>>`
+could be repurposed. 
+
+Option 3 is selected as it is the best option without giving up.
+
+
+## Additional Notes
+
+### Distinctiveness of alternative Unicode bracket characters
+
+It is worth noting that the lack of distinction between (say) angle brackets
+and the `<` and `>` symbols might be addressed by a wise font choice. But
+making Monogram succeed on the basis of selecting custom fonts is not an
+option we should entertain.
+
+
+### The difficulty in parsing
+
+The issue we have is that, using recursive descent, we cannot resolve whether
+`|` is part of the bracket or a prefix operator `|` in the below sequence of
+tokens.
+
+```
+f[|long_expression ....
+```
+
+Obviously we can try one and then revert to the other if it fails. But that 
+leads texts that take an exponential amount of time to parse.
+
+### An approach to parsing
+
+However, if we simply scan ahead linking paired open/close brackets together (and
+linking to the following/prior token) then we limit the impact to a
+single scan of the input. 
+
+In our reference implementation we perform a full input scan anyway, so this
+has a negligible overhead. We simply augment the scan with an FSA with pushdown
+stack.
+
+### Future expansion
+
+However, we intend to support the ability to pre-compile a limited grammar. And
+the tool uses that limited grammer to allow a bit more readability and a lot
+more robustness. In this scenario there would be no need to support arbitrary 
+lookahead - apart from this requirement.
+
+On the other hand, in this scenario, it will be relatively rare to support
+`|` as a prefix operator. It does occur, for example in Verilog it appears as a 
+multi-argument bitwise-or. But such use-cases are not frequent. As a consequence 
+the lookahead is only triggered when:
+
+- The compiled grammar includes prefix `|`.
+- And includes the use of extended literals.
+- And `[|` occurs in the text, with no intervening whitespace.
+
+This is not going to be a mainstream scenario, so I think the concern is 
+quite modest.
+
+And it is worth adding that table-drive parsers might be able to cope with the
+ambiguity without much difficulty anyway.
+
+
+
+
+
+
+

--- a/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
+++ b/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
@@ -38,7 +38,7 @@ and the second as follows:
 ```
 
 In this second example the default type would be `_` by default but could be
-overidden by the `--default-type=TYPENAME` option or the more elaborate option:
+overridden by the `--default-type=TYPENAME` option or the more elaborate option:
 
 ```
 --match-type=TYPENAME,REGEX

--- a/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
+++ b/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
@@ -14,10 +14,10 @@ Possible candidates would be:
 
 | Title                 | Open        | Close       | Example            | ASCII                |
 | --------------------- | ----------- | ----------- | ------------------ | -------------------- |
-| Angle Brackets        | 〈 (U+2329) | 〉 (U+232A) | date〈2025-05-20〉 | date<_2025-05-20_> |
-| Double Angle Brackets | « (U+00AB)  | » (U+00BB)  | date«2025-05-20»   | date<<2025-05-20>>   |
-| White Square Brackets | ⟦ (U+27E6)  | ⟧ (U+27E7)  | date⟦2025-05-20⟧   | date[\|2025-05-20\|] |
-| White Parentheses | ⦅ (U+2985)  | ⦆ (U+2986)  | date⦅2025-05-20⦆   | date(\|2025-05-20\|) |
+| Angle Brackets        | 〈 (U+2329) | 〉 (U+232A) | `date〈2025-05-20〉` | `date<_2025-05-20_>` |
+| Double Angle Brackets | « (U+00AB)  | » (U+00BB)  | `date«2025-05-20»`  | `date<<2025-05-20>>`   |
+| White Square Brackets | ⟦ (U+27E6)  | ⟧ (U+27E7)  | `date⟦2025-05-20⟧`   | `date[\|2025-05-20\|]` |
+| White Parentheses | ⦅ (U+2985)  | ⦆ (U+2986)  | `date⦅2025-05-20⦆`   | `date(\|2025-05-20\|)` |
 
 The specific proposal is to write literals in the following two styles:
 

--- a/docs/decisions/0021-literals-for-regular-expressions/0021-literals-for-regular-expressions.md
+++ b/docs/decisions/0021-literals-for-regular-expressions/0021-literals-for-regular-expressions.md
@@ -1,0 +1,44 @@
+# 0021 - Literals for Regular Expressions, 2025-05-24
+
+## Issue
+
+Regular expressions are an important category that deserve their own
+literal notation. In this decision record we make a specific proposal
+to use the unicode symbol `⫽`. Hence `⫽the (cat|dog) sat on the mat\.⫽ 
+would turn into:
+
+```xml
+<literal type="regex" value="the (cat|dog) sat on the mat\." >
+```
+
+Only one option is considered.
+
+## Factors
+
+- Must be mnemonic
+- Must have an ASCII fallback option
+- Must align with the new literal extension syntax
+
+
+## Pros and Cons
+
+- Pros
+    - The `⫽` symbol is visually similar to the `/` syntax of Perl, which
+      is often used to denote such literals
+- Cons
+    - Copilot warns that not all fonts support this character. 
+      - Our constituency is programmers working in plain text editors,
+        typically using programming fonts. So this is likely an acceptable
+        situation.
+- Interesting
+    - The existing literal extension syntax works as an ASCII fallback 
+      `regex[|the (cat|dog) sat on the mat\.|]`
+    - We only need to ensure the generated AST is identical in both cases.
+
+
+
+## Outcome and Consequences
+
+Adopting this syntax does mean that Monogram programmers are increasingly
+reliant on being able to type these characters _or_ for the editor to 
+perform automatic substitution.


### PR DESCRIPTION
This PR proposes support for regex literals of the form `⫽the (cat|dog) sat on the mat\.⫽`