### PR TITLE
Add Regular Expression literals

### DIFF
--- a/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
+++ b/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
@@ -51,6 +51,6 @@ is the basis on which we make that decision?
 
 ## Outcome and Consequences
 
-Option 2 would be a receipe for failure. Option 1 is no fun. Option 3 wins on 
+Option 2 would be a recipe for failure. Option 1 is no fun. Option 3 wins on 
 balance as the disadvantage is relatively minor.
 

--- a/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
+++ b/docs/decisions/0019-unicode-characters-beyond-ascii/0019-unicode-characters-beyond-ascii.md
@@ -1,0 +1,56 @@
+# 0019 - Unicode characters beyond ASCII, 2025-05-20
+
+## Issue
+
+Should we expand the characters used in Monogram beyond Latin-1? And if so, what
+is the basis on which we make that decision?
+
+## Factors
+
+- Low adoption rates of programming languages that have gone beyond ASCII, let
+  alone Latin-1 e.g. APL, J, K, Uiua.
+- Difficulty in typing arbitrary Unicode characters.
+- Expansion in available syntax for improved readability.
+- Broad adoption of UTF-8 in text editors.
+- The existing inclusion of symbols for non-finite values, paired with
+  ASCII equivalents (`∞`, `0n1` etc).
+
+## Options
+
+- Option 1: Restrict the input to 7-bit ASCII
+- Option 2: Allow UTF-8
+- Option 3: Allow UTF-8 when paired with ASCII equivalents
+
+## Pros and Cons of Options
+
+### Option 1: Restrict the input to 7-bit ASCII
+- Pros
+  - Follows established and successful conventions
+  - Simplicity and clarity of policy
+- Cons
+  - Limits syntax expansion
+  - Misses the chance to use fun and helpful symbols
+
+### Option 2: Allow UTF-8
+- Pros
+  - Makes available fun and helpful symbols
+- Cons
+  - At the expense of a lack of familiarity
+  - Awkward to type for a high percentage of programmers
+
+### Option 3: Allow UTF-8 when paired with ASCII equivalents
+- Pros
+  - Makes available fun and helpful symbols
+- Cons
+  - Two versions of every symbol is a nuisance to remember
+    - So they must be memorable
+- Interesting
+  - Having an ASCII version means that a VSCode plug-in could perform
+    automatic substitution.
+
+
+## Outcome and Consequences
+
+Option 2 would be a receipe for failure. Option 1 is no fun. Option 3 wins on 
+balance as the disadvantage is relatively minor.
+

--- a/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
+++ b/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
@@ -1,0 +1,198 @@
+# 0020 - Extensible Literals, 2025-05-20
+
+## Issue
+
+To support extensible literals of arbitrary type, such as regular expressions,
+dates or IP addresses, we need some kind of innovation. For example it would be
+helpful to extend strings to indicate the intended type. We already have
+something very similar with the `specifier` attribute on multi-line strings.
+
+In this article we explore the options for supporting a specifier on strings
+and possibly other data types.
+
+## Factors
+
+- Syntactic elegance
+- Syntactic footprint
+- Mnemonic quality
+- Consistency with existing design
+- Escaping: whatever we use to capture the literal text must support the 
+  same kind of quoting as strings.
+- Impact on the parser
+- ASCII pairing if unicode is used.
+
+## Options
+
+In these examples we `date` as the specifier and a random date in ISO 8601 
+format as the working example. 
+
+- Option 1a: `date'2025-05-17'` an identifier immediately followed by string,
+  which is currently an impossible combination.
+- Option 1b: `@date'2025-05-17'` as (1a) but introduced wth `@`.
+- Option 1c: `$date'2025-05-17'` as (1a) but introduced wth `$`.
+- Option 1d: `#date'2025-05-17'` as (1a) but introduced wth `#`.
+- Option 2: `date«2025-05-17»`, with variants (a)-(d)
+- Option 3: `@date[2025-05-17]`, with variants (b)-(d)
+- Option 4: Do not have extensible literals.
+
+## Pros and Cons of Options
+
+### Option 1a: Identifier followed by a string
+
+- Pros
+    - Terse, with zero syntactic footprint.
+    - Includes string notation, so all the single-line string variants apply.
+    - Escaping is completely solved.
+    - Trivial parser-only implementation, extending readIdentifier.
+
+- Cons
+    - Quite clunky looking.
+    - Vulnerable to single-character typo problems e.g. `data|'foo'`.
+
+
+### Option 1b: With @ prefix
+
+- Pros
+    - Visually distinctive
+    - Mnemonic, as the `@` symbol is often used to indicate attributes
+    - Elegant implementation possible.
+
+- Cons
+    - Still a bit clunky-looking.
+    - Big syntactic footprint, using the `@` symbol for a niche role.
+
+
+### Option 1c: With $ prefix
+
+- Pros
+    - Visually distinctive
+    - Elegant implementation possible.
+
+- Cons
+    - Not at all mnemonic.
+    - Still a bit clunky-looking.
+    - Big syntactic footprint, using the `$` symbol for a niche role.
+
+- Interesting
+    - This option is dominated by (1b)
+
+### Option 1d: With # prefix
+
+- Pros
+    - Visually distinctive
+    - Elegant implementation possible BUT requires changing comment convention.
+
+- Cons
+    - Clashes with comment syntax
+    - Otherwise it has a minute syntactic footprint
+    - Some mnemonic quality as languages such as Common Lisp use `#` in a
+      similar way.
+    - Still a bit clunky-looking.
+
+- Interesting
+    - Using `#` for nothing but comments is very clear but I do think it 
+      is a waste of a flexible symbol.
+    - The change would be to require `#` comments to be followed by a space,
+      newline, `!`, or two futher hashes. 
+    - Other sequences would cause an error.
+    - This would have the incidental,  beneficial effect of outlawing comments
+      that are glued to the leading `#`, which is visually cluttered.
+
+### Option 2a: Allow guillemets as string quotes
+
+This option requires that we can use « and » as string quotes. Because these
+fall outside of the ASCII set we would need them paired. The obvious pairing
+is by falling-back to options (1a). 
+
+- Pros
+    - Very natural use of these speech marks.
+    - Visually distinctive and clean
+    - Simple implementation.
+
+- Cons
+    - The fallback option means we cannot rate this option above (1a).
+    - Syntactic footprint is significant.
+
+### Option 2b-2d: Allow guillemets as string quotes with @, $ or # prefix
+
+This option requires that we can use « and » as string quotes. Because these
+fall outside of the ASCII set we would need them paired. The obvious pairing
+is by falling-back to options (1b)-(1d) respectively. 
+
+- Pros
+    - Very natural use of these speech marks.
+    - Visually distinctive and clean
+    - Simple implementation.
+
+- Cons
+    - Syntactic footprint is very high when teamed with options (1b) and (1c)
+      and high when teamed with (1d).
+
+- Interesting
+    - Since (1b) dominates (1c) the choice is between `@` and `#` which
+      is a straight trade-off between mnemonic quality vs altering 
+      end-of-line comments.
+
+### Option 3b-3d: `@date[2025-05-17]`
+
+- Cons
+    - Asking people to read `[...]` as string quotes is a horrible conflation
+      of roles. Showstopper.
+
+### Option 4: Don't have extensible literals
+
+- Pros
+    - Simple to learn
+- Cons
+    - We force programmers to represent dates, IP addresses, colours as 
+      strings and to use function calls to convert them. 
+      - But Monogram has no built-in function calls, which pushes the 
+        effort back to the developer.
+
+
+## Outcome and Consequences
+
+Despite the heavy syntactic footprint, Option (2b) with Option (1b) as the ASCII
+fallback is visually distinctive, clean looking, with an easy implementation and
+escaping a fully solved problem - and is my pick of the bunch.
+
+- `@date«2025-05-25»`
+
+This would be translated into:
+
+```xml
+<string quote="chevron" specifier="date" value="2025-05-25" />
+```
+
+
+## Additional Notes
+
+Do extended literals make any sense in combination with raw strings, multiline
+strings and string interpolation? 
+
+Certainly raw strings make complete sense. The syntax is not exactly beautiful
+but for regular expressions might look like: `@re\«\w+»`. Since this is such 
+a common requirement for regular expressions we will be proposing separate 
+raw-regex syntax.
+
+String interpolation is much less clear, since an interpolated string is
+something of a compound literal. My view here is that if it is good for strings
+it must be potentially good for other things - but `join` must be sensitive to
+the target type.
+
+Here I propose that: ``@txt«This is my \(thing)»` becomes:
+
+```xml
+<join quote="double" specifier="txt">
+    <string quote="double" value="This is my " specifier="" />
+    <interpolation kind="parentheses">
+        <identifier name="thing" />
+    </interpolation>
+</join>
+```
+
+In other words the specifier is floated to the outer level and the interior
+strings are simply neutral.
+
+Multiline strings already, in fact, handle specifiers, so the only change would
+be to add the `specifier` attribute to the individual lines.

--- a/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
+++ b/docs/decisions/0020-extensible-literals/0020-extensible-literals.md
@@ -31,6 +31,7 @@ format as the working example.
 - Option 1b: `@date'2025-05-17'` as (1a) but introduced wth `@`.
 - Option 1c: `$date'2025-05-17'` as (1a) but introduced wth `$`.
 - Option 1d: `#date'2025-05-17'` as (1a) but introduced wth `#`.
+- Option 1e: `.date'2025-05-17'` as (1a) but introduced wth `.`.
 - Option 2: `date«2025-05-17»`, with variants (a)-(d)
 - Option 3: `@date[2025-05-17]`, with variants (b)-(d)
 - Option 4: Adopt `@` as raw-string signifier and « » as alternative string quotes
@@ -88,12 +89,12 @@ format as the working example.
 - Pros
     - Visually distinctive
     - Elegant implementation possible BUT requires changing comment convention.
+    - Limited mnemonic quality, languages such as Common Lisp use `#` in a
+      similar way.
 
 - Cons
     - Clashes with comment syntax
-    - Otherwise it has a minute syntactic footprint
-    - Some mnemonic quality as languages such as Common Lisp use `#` in a
-      similar way.
+    - Otherwise it has a small syntactic footprint
     - Still a bit clunky-looking.
 
 - Interesting
@@ -104,6 +105,23 @@ format as the working example.
     - Other sequences would cause an error.
     - This would have the incidental,  beneficial effect of outlawing comments
       that are glued to the leading `#`, which is visually cluttered.
+
+### Option 1e: With a . prefix
+
+e.g. `.date'2025-05-17'`
+
+- Pros
+  - Mnemonic - reminiscent of a file extension!
+  - No syntactic footprint because prefix `.` is not defined.
+
+- Cons
+  - Visually confusable with infix `.`.
+
+- Interesting
+  - Works very well in combination with `@` for raw strings where it looks
+    like a tiny version of `@`.
+  - The unicode 'label' character (🏷️) could be considered its non-ASCII 
+    equivalent.
 
 ### Option 2a: Allow guillemets as string quotes
 
@@ -146,33 +164,46 @@ is by falling-back to options (1b)-(1d) respectively.
     - Asking people to read `[...]` as string quotes is a horrible conflation
       of roles. Showstopper.
 
-### Option 4L Option 1a but Adopt @ to signify raw-strings and « » as alternative string quotes
+### Option 4: Option 1e with @ for raw-string, « » as alt quotes
 
 This option emerged as I worked on this decision and seemed to have a lot 
 going for it. The basic idea is that:
 
 1. We use `@` to signify raw-string literals. This is a good idea anyway as
-   reusing `\` is clever but visually confusing. We also retire the leading
-   escape. Precedent here is C#.
+   reusing `\` is clever but visually confusing. Precedent here is C#.
+2. We retire `\` from indicating rawness.
 2. We adopt `« »` as string quotes (using `chevron` as the quote attribute value).
    Again this is a good idea as these quotes are visually distinctive.
-3. We adopt the full string syntax as an optional `@` followed by an 
+3. We adopt the full raw string syntax as an optional `@` followed by an 
    optional identifier (specifier) followed by a string.
+4. We use `.` to introduce tagged non-raw strings.
+
+Examples:
+
+- `@date'2025-05-17'` - raw date, ASCII only
+- `.date«2025-05-\(date)»` - non-raw interpolated date, with chevrons
 
 Making raw strings easier to write is key, since regular expressions in 
 particular typically need to be written raw.
 
 - Pros
-  - Straightforward design with reusable elements
+  - Straightforward design with reusable elements.
   - The use of chevrons make the separation from the specifier-identifier nice
     and clear.
-  - The `@` symbol as a raw-string indicator fixes an existing issue.
+  - The `@` symbol as a raw-string indicator is a big improvement on the 
+    leading backslash.
 
 - Cons
-  - The non-raw fallback to ASCII is clunky: `date"2025-05-25"`. In
+  - The non-raw fallback to ASCII is not beautiful: `.date"2025-05-25"`. In
     general it will look neater with raw strings `@date"2025-05-25"`.
-  - A heavy syntactic footprint which is significantly ameliorated by the
-    fact `@` is reusable.
+  - Dedicating the character `@` is a heavy syntactic footprint
+    - But the role is not limited to tags.
+    - Using it to denote raw-ness brings the footprint more into balance
+      with its utility.
+
+- Interesting
+  - The unicode 'label' character (🏷️) could be considered the non-ASCII 
+    equivalent to prefix `.`.
 
 ### Option 5: Don't have extensible literals
 

--- a/docs/decisions/0021-literals-for-regular-expressions/0021-literals-for-regular-expressions.md
+++ b/docs/decisions/0021-literals-for-regular-expressions/0021-literals-for-regular-expressions.md
@@ -1,0 +1,45 @@
+# 0021 - Literals for Regular Expressions, 2025-05-24
+
+## Issue
+
+Regular expressions are an important category that deserve their own
+literal notation. In this decision record we make a specific proposal
+to use the unicode symbol `⫽`. Hence `⫽the (cat|dog) sat on the mat\.⫽ 
+would turn into:
+
+```xml
+<literal type="regex" value="the (cat|dog) sat on the mat\." >
+```
+
+Note that the contents between the opening and closing quotes are
+_raw_ in the sense that no string escapes are enabled.
+
+## Factors
+
+- Must be mnemonic
+- Must have an ASCII fallback option
+- Must align with the new literal extension syntax
+
+
+## Pros and Cons
+
+- Pros
+    - The `⫽` symbol is visually similar to the `/` syntax of Perl, which
+      is often used to denote such literals.
+- Cons
+    - Copilot warns that not all fonts support this character. 
+      - Our constituency is programmers working in plain text editors,
+        typically using programming fonts. So this is likely an acceptable
+        situation.
+- Interesting
+    - The existing literal extension syntax works as an ASCII fallback 
+      `@regex\«the (cat|dog) sat on the mat\.»`
+    - We only need to ensure the generated AST is identical in both cases.
+
+
+
+## Outcome and Consequences
+
+Adopting this syntax does mean that Monogram programmers are increasingly
+reliant on being able to type these characters _or_ for the editor to 
+perform automatic substitution.


### PR DESCRIPTION
This PR proposes support for regex literals of the form ⫽the (cat|dog) sat on the mat\.⫽.